### PR TITLE
Add MinIO storage backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ To persist your pod's contents between restarts, use:
 ```shell
 npx @solid/community-server -c @css:config/file.json -f data/
 ```
+To store data in a MinIO/S3 backend, use:
+```shell
+npx @solid/community-server -c @css:config/minio.json
+```
 
 In case you prefer to use Docker instead,
 you can find instructions for this and other methods in the

--- a/config/minio.json
+++ b/config/minio.json
@@ -1,0 +1,41 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld",
+  "import": [
+    "css:config/app/init/static-root.json",
+    "css:config/app/main/default.json",
+    "css:config/app/variables/default.json",
+    "css:config/http/handler/default.json",
+    "css:config/http/middleware/default.json",
+    "css:config/http/notifications/all.json",
+    "css:config/http/server-factory/http.json",
+    "css:config/http/static/default.json",
+    "css:config/identity/access/public.json",
+    "css:config/identity/email/default.json",
+    "css:config/identity/handler/default.json",
+    "css:config/identity/oidc/default.json",
+    "css:config/identity/ownership/token.json",
+    "css:config/identity/pod/static.json",
+    "css:config/ldp/authentication/dpop-bearer.json",
+    "css:config/ldp/authorization/webacl.json",
+    "css:config/ldp/handler/default.json",
+    "css:config/ldp/metadata-parser/default.json",
+    "css:config/ldp/metadata-writer/default.json",
+    "css:config/ldp/modes/default.json",
+    "css:config/storage/backend/minio.json",
+    "css:config/storage/key-value/resource-store.json",
+    "css:config/storage/location/pod.json",
+    "css:config/storage/middleware/default.json",
+    "css:config/util/auxiliary/acl.json",
+    "css:config/util/identifiers/suffix.json",
+    "css:config/util/index/default.json",
+    "css:config/util/logging/winston.json",
+    "css:config/util/representation-conversion/default.json",
+    "css:config/util/resource-locker/memory.json",
+    "css:config/util/variables/default.json"
+  ],
+  "@graph": [
+    {
+      "comment": "A Solid server that stores its resources on MinIO and uses WAC for authorization."
+    }
+  ]
+}

--- a/config/storage/backend/data-accessors/minio.json
+++ b/config/storage/backend/data-accessors/minio.json
@@ -1,0 +1,17 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld",
+  "@graph": [
+    {
+      "comment": "Stores data on a MinIO or S3 backend.",
+      "@id": "urn:solid-server:default:MinioDataAccessor",
+      "@type": "MinioDataAccessor",
+      "endPoint": "localhost",
+      "port": 9000,
+      "useSSL": false,
+      "accessKey": "minioadmin",
+      "secretKey": "minioadmin",
+      "bucket": "css",
+      "identifierStrategy": { "@id": "urn:solid-server:default:IdentifierStrategy" }
+    }
+  ]
+}

--- a/config/storage/backend/minio.json
+++ b/config/storage/backend/minio.json
@@ -1,0 +1,17 @@
+{
+  "@context": "https://linkedsoftwaredependencies.org/bundles/npm/@solid/community-server/^7.0.0/components/context.jsonld",
+  "import": [
+    "css:config/storage/backend/data-accessors/minio.json"
+  ],
+  "@graph": [
+    {
+      "comment": "A default store setup with a MinIO backend.",
+      "@id": "urn:solid-server:default:ResourceStore_Backend",
+      "@type": "DataAccessorBasedStore",
+      "identifierStrategy": { "@id": "urn:solid-server:default:IdentifierStrategy" },
+      "auxiliaryStrategy": { "@id": "urn:solid-server:default:AuxiliaryStrategy" },
+      "accessor": { "@id": "urn:solid-server:default:MinioDataAccessor" },
+      "metadataStrategy": { "@id": "urn:solid-server:default:MetadataStrategy" }
+    }
+  ]
+}

--- a/documentation/markdown/usage/starting-server.md
+++ b/documentation/markdown/usage/starting-server.md
@@ -15,6 +15,10 @@ To persist your pod's contents between restarts, use:
 ```shell
 npx @solid/community-server -c @css:config/file.json -f data/
 ```
+To run the server with a MinIO/S3 backend, use:
+```shell
+npx @solid/community-server -c @css:config/minio.json
+```
 
 ## Local installation
 
@@ -34,6 +38,10 @@ To run the server with your current folder as storage, use:
 
 ```shell
 community-solid-server -c @css:config/file.json -f data/
+```
+To run the server with a MinIO/S3 backend, use:
+```shell
+community-solid-server -c @css:config/minio.json
 ```
 
 ## Configuring the server
@@ -56,7 +64,7 @@ to some commonly used settings:
 | `--baseUrl, -b`         | `http://localhost:$PORT/`  | The base URL used internally to generate URLs. Change this if your server does not run on `http://localhost:$PORT/`.                          |
 | `--socket`              |                            | The Unix Domain Socket on which the server should listen. `--baseUrl` must be set if this option is provided                                  |
 | `--loggingLevel, -l`    | `info`                     | The detail level of logging; useful for debugging problems. Use `debug` for full information.                                                 |
-| `--config, -c`          | `@css:config/default.json` | The configuration(s) for the server. The default only stores data in memory; to persist to your filesystem, use `@css:config/file.json`       |
+| `--config, -c`          | `@css:config/default.json` | The configuration(s) for the server. The default only stores data in memory; to persist to your filesystem, use `@css:config/file.json`. For MinIO/S3 storage use `@css:config/minio.json` |
 | `--rootFilePath, -f`    | `./`                       | Root folder where the server stores data, when using a file-based configuration.                                                              |
 | `--sparqlEndpoint, -s`  |                            | URL of the SPARQL endpoint, when using a quadstore-based configuration.                                                                       |
 | `--showStackTrace, -t`  | false                      | Enables detailed logging on error output.                                                                                                     |

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "lodash.orderby": "^4.6.0",
     "marked": "^9.1.0",
     "mime-types": "^2.1.35",
+    "minio": "^7.0.0",
     "n3": "^1.17.1",
     "nodemailer": "^6.9.9",
     "oidc-provider": "^8.4.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -446,6 +446,7 @@ export * from './storage/accessors/DataAccessor';
 export * from './storage/accessors/FileDataAccessor';
 export * from './storage/accessors/FilterMetadataDataAccessor';
 export * from './storage/accessors/InMemoryDataAccessor';
+export * from './storage/accessors/MinioDataAccessor';
 export * from './storage/accessors/PassthroughDataAccessor';
 export * from './storage/accessors/SparqlDataAccessor';
 export * from './storage/accessors/ValidatingDataAccessor';

--- a/src/storage/accessors/MinioDataAccessor.ts
+++ b/src/storage/accessors/MinioDataAccessor.ts
@@ -1,0 +1,168 @@
+import type { Readable } from 'node:stream';
+import { Client } from 'minio';
+import type { Representation } from '../../http/representation/Representation';
+import { RepresentationMetadata } from '../../http/representation/RepresentationMetadata';
+import type { ResourceIdentifier } from '../../http/representation/ResourceIdentifier';
+import { getLoggerFor } from '../../logging/LogUtil';
+import { NotFoundHttpError } from '../../util/errors/NotFoundHttpError';
+import { UnsupportedMediaTypeHttpError } from '../../util/errors/UnsupportedMediaTypeHttpError';
+import { guardStream } from '../../util/GuardedStream';
+import type { Guarded } from '../../util/GuardedStream';
+import { serializeQuads, parseQuads } from '../../util/QuadUtil';
+import { isContainerIdentifier } from '../../util/PathUtil';
+import type { IdentifierStrategy } from '../../util/identifiers/IdentifierStrategy';
+import type { DataAccessor } from './DataAccessor';
+
+export interface MinioDataAccessorOptions {
+  endPoint: string;
+  port: number;
+  useSSL: boolean;
+  accessKey: string;
+  secretKey: string;
+  bucket: string;
+  identifierStrategy: IdentifierStrategy;
+}
+
+/**
+ * DataAccessor that stores data on a MinIO/S3 backend.
+ */
+export class MinioDataAccessor implements DataAccessor {
+  protected readonly logger = getLoggerFor(this);
+  private readonly client: Client;
+  private readonly bucket: string;
+  private readonly identifierStrategy: IdentifierStrategy;
+
+  public constructor(options: MinioDataAccessorOptions) {
+    this.client = new Client({
+      endPoint: options.endPoint,
+      port: options.port,
+      useSSL: options.useSSL,
+      accessKey: options.accessKey,
+      secretKey: options.secretKey,
+    });
+    this.bucket = options.bucket;
+    this.identifierStrategy = options.identifierStrategy;
+  }
+
+  private keyFor(identifier: ResourceIdentifier, isMeta = false): string {
+    let key = identifier.path.startsWith('/') ? identifier.path.slice(1) : identifier.path;
+    if (isMeta) {
+      key += '.meta';
+    }
+    return key;
+  }
+
+  public async canHandle(representation: Representation): Promise<void> {
+    if (!representation.binary) {
+      throw new UnsupportedMediaTypeHttpError('Only binary data is supported.');
+    }
+  }
+
+  public async getData(identifier: ResourceIdentifier): Promise<Guarded<Readable>> {
+    try {
+      const stream: Readable = await new Promise((resolve, reject): void => {
+        this.client.getObject(this.bucket, this.keyFor(identifier), (err, data) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve(data);
+          }
+        });
+      });
+      return guardStream(stream);
+    } catch (err: any) {
+      this.logger.warn(`Data not found for ${identifier.path}`);
+      throw new NotFoundHttpError();
+    }
+  }
+
+  public async getMetadata(identifier: ResourceIdentifier): Promise<RepresentationMetadata> {
+    try {
+      const stream: Readable = await new Promise((resolve, reject): void => {
+        this.client.getObject(this.bucket, this.keyFor(identifier, true), (err, data) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve(data);
+          }
+        });
+      });
+      const quads = await parseQuads(guardStream(stream), { format: 'text/turtle', baseIRI: identifier.path });
+      return new RepresentationMetadata(identifier).addQuads(quads);
+    } catch (err: any) {
+      this.logger.warn(`Metadata not found for ${identifier.path}`);
+      throw new NotFoundHttpError();
+    }
+  }
+
+  public async* getChildren(identifier: ResourceIdentifier): AsyncIterableIterator<RepresentationMetadata> {
+    const prefix = this.keyFor(identifier).replace(/\/?$/, '/');
+    const stream = this.client.listObjectsV2(this.bucket, prefix, false);
+    const objects: string[] = [];
+    await new Promise((resolve, reject): void => {
+      stream.on('data', (obj) => {
+        if (!obj.name.endsWith('.meta')) {
+          objects.push(obj.name);
+        }
+      });
+      stream.on('end', resolve);
+      stream.on('error', reject);
+    });
+    for (const name of objects) {
+      const id = { path: '/' + name };
+      yield new RepresentationMetadata(id);
+    }
+  }
+
+  public async writeDocument(identifier: ResourceIdentifier, data: Guarded<Readable>, metadata: RepresentationMetadata): Promise<void> {
+    const meta = serializeQuads(metadata.quads(), 'text/turtle');
+    await new Promise((resolve, reject): void => {
+      this.client.putObject(this.bucket, this.keyFor(identifier, true), meta, (err) => err ? reject(err) : resolve(undefined));
+    });
+    await new Promise((resolve, reject): void => {
+      this.client.putObject(this.bucket, this.keyFor(identifier), data, (err) => err ? reject(err) : resolve(undefined));
+    });
+  }
+
+  public async writeContainer(identifier: ResourceIdentifier, metadata: RepresentationMetadata): Promise<void> {
+    const meta = serializeQuads(metadata.quads(), 'text/turtle');
+    await new Promise((resolve, reject): void => {
+      this.client.putObject(this.bucket, this.keyFor(identifier, true), meta, (err) => err ? reject(err) : resolve(undefined));
+    });
+    await new Promise((resolve, reject): void => {
+      this.client.putObject(this.bucket, this.keyFor(identifier), Buffer.alloc(0), (err) => err ? reject(err) : resolve(undefined));
+    });
+  }
+
+  public async writeMetadata(identifier: ResourceIdentifier, metadata: RepresentationMetadata): Promise<void> {
+    const meta = serializeQuads(metadata.quads(), 'text/turtle');
+    await new Promise((resolve, reject): void => {
+      this.client.putObject(this.bucket, this.keyFor(identifier, true), meta, (err) => err ? reject(err) : resolve(undefined));
+    });
+  }
+
+  public async deleteResource(identifier: ResourceIdentifier): Promise<void> {
+    await new Promise((resolve) => {
+      this.client.removeObject(this.bucket, this.keyFor(identifier, true), () => resolve(undefined));
+    });
+    if (isContainerIdentifier(identifier)) {
+      const prefix = this.keyFor(identifier).replace(/\/?$/, '/');
+      const stream = this.client.listObjectsV2(this.bucket, prefix, true);
+      const names: string[] = [];
+      await new Promise((resolve, reject): void => {
+        stream.on('data', (obj) => names.push(obj.name));
+        stream.on('end', resolve);
+        stream.on('error', reject);
+      });
+      if (names.length > 0) {
+        await new Promise((resolve, reject): void => {
+          this.client.removeObjects(this.bucket, names, (err) => err ? reject(err) : resolve(undefined));
+        });
+      }
+    } else {
+      await new Promise((resolve) => {
+        this.client.removeObject(this.bucket, this.keyFor(identifier), () => resolve(undefined));
+      });
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- implement `MinioDataAccessor` for MinIO/S3 object storage
- expose the accessor in the public index
- add configuration files for the new backend
- document how to run the server using MinIO
- list new `minio` dependency

## Testing
- `npx tsc --noEmit` *(fails: File '@tsconfig/node18/tsconfig.json' not found)*

------
https://chatgpt.com/codex/tasks/task_b_686cc10c61908328beee6767628886eb